### PR TITLE
Fixing orientation bug in sky_image_plot and adapting run_4 demo

### DIFF
--- a/pydeimos/sky_image_plot.py
+++ b/pydeimos/sky_image_plot.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 class SkyImage(object):
     """Holds a pixel array
     
+    Todo : use properties for z1 z2 !
     """
     
     def __init__(self, data, z1=None, z2=None):
@@ -49,24 +50,32 @@ class SkyImage(object):
         """
                
         self.data = data
-        self.extent = (0, self.data.shape[0], 0, self.data.shape[1])
+        self.extent = get_extent(self.data)
+        self.z1 = z1
+        self.z2 = z2
+        logger.debug("SkyImage initialization with z1={} and z2={}".format(z1, z2))
         self.set_z(z1, z2)
         
         logger.info("Created {}".format(str(self)))
 
+    @property
+    def shape(self): # Just a shortcut
+        """The shape (width, height) of the image"""
+        return self.data.shape
+    
     def __str__(self):
-        return "SkyImage{}".format(self.data.shape)
+        return "SkyImage{}[{}:{}]".format(self.shape, self.z1, self.z2)
     
 
     def set_z(self, z1, z2):
         
         if z1 is None:
-            self.z1 = np.min(data)
+            self.z1 = np.min(self.data)
             logger.info("Set z1 to minimum value: {}".format(self.z1))
         else:
             self.z1 = z1
         if z2 is None:
-            self.z2 = np.max(data)
+            self.z2 = np.max(self.data)
             logger.info("Set z2 to maximum value: {}".format(self.z2))
         else:
             self.z2 = z2
@@ -111,26 +120,34 @@ def draw_sky_image(ax, si, **kwargs):
     """Use imshow to draw a SkyImage to some axes
     
     """
+    # "origin":"lower" as well as the tranpose() within the imshow arguments both combined give the right orientation
     imshow_kwargs = {"aspect":"equal", "origin":"lower", "interpolation":"none", "cmap":matplotlib.cm.get_cmap('Greys_r')}
     imshow_kwargs.update(kwargs)
     
-    return ax.imshow(si.data, vmin=si.z1, vmax=si.z2, extent=si.extent, **imshow_kwargs)
+    return ax.imshow(si.data.transpose(), vmin=si.z1, vmax=si.z2, extent=si.extent, **imshow_kwargs)
 
 
 
 def draw_mask(ax, si, **kwargs):
     """Uses imshow to draw a binary mask to some axes
     
+    Parameters
+    si : SkyImage
+        The mask, can also be a plain 2D numpy array
+    
     """
-
+        
     mask_cmap = matplotlib.colors.ListedColormap([(1.0, 1.0, 1.0, 0.0), (1.0, 0.0, 0.0, 0.6)])
     mask_bounds=[-1,0.5,1]
     mask_norm = matplotlib.colors.BoundaryNorm(mask_bounds, mask_cmap.N)
 
     imshow_kwargs = {"aspect":"equal", "origin":"lower", "interpolation":"none", "alpha":0.5}
     imshow_kwargs.update(kwargs)
-  
-    return ax.imshow(si.data, vmin=0, vmax=1, extent=si.extent, cmap=mask_cmap, norm=mask_norm, **imshow_kwargs)
+    
+    if isinstance(si, SkyImage):
+        return ax.imshow(si.data.tranpose(), vmin=0, vmax=1, extent=si.extent, cmap=mask_cmap, norm=mask_norm, **imshow_kwargs)
+    else: # We can also work with simple numpy arrays
+        return ax.imshow(si.transpose(), vmin=0, vmax=1, extent=get_extent(si), cmap=mask_cmap, norm=mask_norm, **imshow_kwargs)
     
 
 def draw_ellipse(ax, x, y, a=5, b=None, angle=None, **kwargs):
@@ -233,7 +250,9 @@ class SimpleFigure(object):
 
         """
         
-        self.si = SkyImage(img_array, z1, z2)
+        self.img_array = img_array
+        self.z1 = z1
+        self.z2 = z2
         
         self.dpi = 72
         self.figsize = float(scale) * np.array(img_array.shape)/self.dpi
@@ -241,12 +260,28 @@ class SimpleFigure(object):
         self.fig = plt.figure(figsize=self.figsize)
         self.ax = self.fig.add_subplot(111)
         
-        draw_sky_image(self.ax, self.si)
+        self.has_been_drawn = False
+        
         
 
     def __str__(self):
-        return "SimpleFigure({})".format(str(self.si))
-            
+        return "SimpleFigure"#({})".format(str(self.si))
+    
+    def draw(self, si=None):
+        """Draw the image pixels on the axes.
+        
+        Usually you leave si to None, in which case a new SkyImage is built from what was passed to init.
+        """
+        if si is None:
+            si = SkyImage(self.img_array, self.z1, self.z2)
+        draw_sky_image(self.ax, si)
+        self.has_been_drawn = True
+    
+    def check_drawn(self):
+        if not self.has_been_drawn:
+            self.draw()
+            #logger.warning("The SimpleFigure has not been drawn, you probably want to call draw() before showing or saving it!")
+        
     def draw_g_ellipses(self, cat, **kwargs):
         draw_g_ellipses(self.ax, cat, **kwargs)
     
@@ -257,79 +292,28 @@ class SimpleFigure(object):
         """Update this once we settle on a minimum matplotlib version...
         
         """
+        self.check_drawn()
         logger.info("Showing {}...".format(str(self)))
         plt.show()
         
+        
     def save_to_file(self, filepath):
+        self.check_drawn()
         logger.info("Saving {} to '{}'...".format(str(self), filepath))
         self.fig.savefig(filepath, bbox_inches='tight')
    
-
-# 
-# def plot(img_array, z1=None, z2=None, mask_array=None, ax=None, filepath=None, figsize=None, scale=1):
-#     """Wraps some of the functionality into a single convenient function 
-#     
-#     Parameters
-#     ----------
-#     img_array : numpy array
-#         A 2D numpy array containing the image
-#     mask_array : numpy array
-#         A 2D numpy array containing a boolean mask (1 means True means masked)
-#     ax : Matplotlib Axes
-#         An Axes object on which to plot the image.
-#         If given, the keywords related to the figure creation are ignored
-#     filepath : string
-#         Path to a file in which to save the figure. If Neither ax nor fielpath is specified, the figure is shown
-#         interactively.
-#     scale : float
-#         A scaling for the display of the image
-#     
-#     """
-#     
-#     if ax is None:
-#         makefig = True
-#     else:
-#         makefig = False
-#         
-#     if makefig:
-#         
-#         dpi = 72.0 
-#         figsize = float(scale) * np.array(img_array.shape)/dpi
-#         
-#         fig = plt.figure(figsize=figsize)
-#         ax = fig.add_subplot(111)
-#     
-#     img_si = SkyImage(img_array)
-#     img_si.set_auto_z_scale()
-#     draw_sky_image(ax, img_si)
-#     
-#     if mask_array is not None:
-#         mask_si = SkyImage(mask_array)
-#         draw_mask(ax, mask_si)
-#     
-#     draw_ellipse(ax, 40, 60, a=5, b=10)
-#     
-#     sigma = 0.1
-#     draw_g_ellipse(ax, -0.5, 0.0, -0.5, 0.0, sigma)
-#     draw_g_ellipse(ax, 0.5, 0.0, 0.5, 0.0, sigma)
-#     draw_g_ellipse(ax, 0.0, 0.5, 0.0, 0.5, sigma)
-#     draw_g_ellipse(ax, 0.0, -0.5, 0.0, -0.5, sigma)
-#     
-#     
-#            
-#     if makefig:
-#         if filepath is None:
-#             plt.show()
-#         else:
-#             logger.info("Writing image to '{}'".format(filepath))
-#             fig.savefig(filepath, bbox_inches='tight')
-#         plt.close(fig)
-#  
 
 
 
 
 # Some utility functions
+
+def get_extent(a):
+    """Defines the extent with which to plot an array a (we use the numpy convention)
+    
+    """
+    return (0, a.shape[0], 0, a.shape[1])
+
     
 def stdmad(a):
     """MAD rescaled to std of normally distributed data"""

--- a/run_4_showresults.py
+++ b/run_4_showresults.py
@@ -13,7 +13,7 @@ obs_image = galsim.fits.read("run_obs_image.fits")
 
 
 # And we visualize the grid and the measurements:
-sf = sip.SimpleFigure(obs_image.array, z1=-3.0, z2=10.0, scale=2) # There is no "tranpose" here, as we've defined the stamps with our own convention, and consistently drawn and measured them with galsim.
+sf = sip.SimpleFigure(obs_image.array.transpose(), z1=-3.0, z2=10.0, scale=2) # There is a "tranpose" here, as GalSim uses (y, x) instead of (x, y)
 
 # The true PSF shape, in blue:
 sf.draw_g_ellipses(catalog, x="tru_gal_x", y="tru_gal_y", g1="tru_psf_g1", g2="tru_psf_g2", sigma="tru_psf_sigma", edgecolor="blue", linewidth=1.0)


### PR DESCRIPTION
Da war doch noch ein Bug in sky_image_plot, die pixel-bilder wurden transposiert angezeigt (und einige andere updates).
An der API ändert sich nichts, nur das man ein GalSim "Image" jetzt transposieren muss um es sky_image_plot zu geben (was auch ganz normal ist, da GalSim (y, x) statt (x, y) verwendet.